### PR TITLE
Fix exception when $this->entry is a string

### DIFF
--- a/src/WysiwygFieldType.php
+++ b/src/WysiwygFieldType.php
@@ -88,7 +88,7 @@ class WysiwygFieldType extends FieldType
      */
     public function getFilePath()
     {
-        if ($this->entry === null || !is_object($this->entry) && !$this->entry->getId()) {
+        if ($this->entry === null || !is_object($this->entry) || !$this->entry->getId()) {
             return null;
         }
 


### PR DESCRIPTION
$this->entry was being checked to see if it isn't an object, and if it isn't an object, getId was being called on this non-object causing an exception.

Now the function will return null if entry is null OR not an object OR the object returns a false Id.
